### PR TITLE
Update Assignment Creation README for Syntax Issue

### DIFF
--- a/ASSIGNMENT_CREATION_README.md
+++ b/ASSIGNMENT_CREATION_README.md
@@ -8,7 +8,7 @@
       the spec are named `fact` and `fib`, then each of the
       wheat/chaff files should have as header:
       ```
-      provide { fact: fact, fib: fib }
+      provide { fact: fact, fib: fib } end
       provide-types *
       ```
     * If any tests are provided within these implementations they


### PR DESCRIPTION
I ran into this syntax error, so I'm fixing it so others don't have the same error. There's also potential for import conflicts when using `provide-types *`, but at least that's syntactically valid.