### PR TITLE
Fix hint styling without jQuery update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test-util/failed-test-screenshots/*
 .coverage/
 *~
 .vscode/**
+.nvmrc
+*.rdb

--- a/src/web/css/editor.css
+++ b/src/web/css/editor.css
@@ -2875,7 +2875,7 @@ ul.chaff_list {
 
 .wheat_list .wheat,
 .chaff_list .chaff {
-  display:block;
+  /* display:block; */
   color: white;
   text-decoration: none;
   padding:0.5em;
@@ -3049,4 +3049,12 @@ li.tab.selected {
   > .file-examplar-summary-message
 {
   background: hsla(0,100%,73%,1);
+}
+
+#hint_box {
+  padding: 5px;
+  background-color: white;
+  border: thick solid white;
+  align-content: center;
+  width: 100%;
 }

--- a/src/web/editor.html
+++ b/src/web/editor.html
@@ -4,20 +4,6 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Examplar</title>
   <link rel="preload" href="{{&PYRET}}" as="script">
-
-<!-- BOOTSTRAP STYLING-->
-  <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
-  <!-- jQuery library -->
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.3/dist/jquery.slim.min.js"></script> -->
-  <!-- Popper JS -->
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-  <!-- Latest compiled JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
-<!-- END BOOTSTRAP STYLING-->
-
-
-
   <link rel="stylesheet" href="/css/reset.css" />
   <link href="https://fonts.googleapis.com/css2?family=Gochi+Hand&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/reset.css"></link>

--- a/src/web/js/check-ui.js
+++ b/src/web/js/check-ui.js
@@ -188,13 +188,6 @@
         container.innerHTML = "Something went wrong, failed to find a hint.";
       }
       finally {
-        // This styling is not ideal but does allow for quick prototyping.
-        container.style.backgroundColor = "white";
-        container.style.borderStyle = "solid";
-        container.style.borderColor = "white";
-        container.style.borderWidth = "thick";
-        container.style.alignContent = "center";
-        container.style.width = "100%";
         container.id = "hint_box";
         return container;
       }
@@ -358,6 +351,7 @@
 
           let c = document.createElement("div");
           c.classList += ["container-fluid"];
+          c.id = "hint_box";
 
             c.innerHTML = (num_wfe == 1) ?
                ` <div class="card-body> 
@@ -371,9 +365,6 @@
               when there is exactly one invalid test. </p>    
               </p> </div>`;
 
-          // TODO: This is not good practice.
-          c.style.padding = '5px'; 
-          c.style.backgroundColor = "white";
           message_elt.parentElement.appendChild(c);
         }
 


### PR DESCRIPTION
Only accept one of this or #46. Both solve the same issue. This one also avoids changes to `package.json` , which may or may not be desirable.