### PR TITLE
Moving hint run identification to run_start event

### DIFF
--- a/src/web/js/repl-ui.js
+++ b/src/web/js/repl-ui.js
@@ -1076,6 +1076,7 @@
                   : s.name.includes("common") ? "common"
                   : null,
                 contents: s.contents,
+                hint_gen: window.hint_run
               }))
         });
 


### PR DESCRIPTION
Improving hint logging to an attribute on the runb_start event so we have tighter coupling